### PR TITLE
Add offline high score saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Local High Scores
+
+When you finish a game while not logged in, you're prompted to enter a name.
+This name is stored in your browser so your best times are saved between
+sessions. The current name is shown in the top left corner of the page and can
+be edited by clicking on it.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/c6172f6d-e92d-40b2-a445-e19bf74e1035) and click on Share -> Publish.

--- a/src/components/GameCompletion.tsx
+++ b/src/components/GameCompletion.tsx
@@ -1,10 +1,12 @@
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
 import { formatTime } from '../utils/gameUtils';
 import { useHighScores } from '@/hooks/useHighScores';
 import { useAuth } from '@/contexts/AuthContext';
+import { usePlayerName } from '@/hooks/usePlayerName';
 
 interface GameCompletionProps {
   timeElapsed: number;
@@ -22,13 +24,15 @@ const GameCompletion: React.FC<GameCompletionProps> = ({
   score = 25
 }) => {
   const { user } = useAuth();
+  const { playerName, setPlayerName } = usePlayerName();
   const { submitScore } = useHighScores(gameMode);
+  const [nameInput, setNameInput] = useState(playerName);
 
   useEffect(() => {
-    if (user) {
+    if (user || playerName) {
       submitScore(score, timeElapsed);
     }
-  }, [user, score, timeElapsed, submitScore]);
+  }, [user, playerName, score, timeElapsed, submitScore]);
 
   return (
     <Card className="p-8 text-center bg-white/80 backdrop-blur-sm">
@@ -36,10 +40,18 @@ const GameCompletion: React.FC<GameCompletionProps> = ({
       <p className="text-xl text-gray-700 mb-4">
         You completed the game in {formatTime(timeElapsed)}!
       </p>
-      {user ? (
+      {user || playerName ? (
         <p className="text-sm text-gray-600 mb-4">Your score has been saved!</p>
       ) : (
-        <p className="text-sm text-gray-600 mb-4">Sign in to save your high scores!</p>
+        <div className="mb-4 space-y-2">
+          <p className="text-sm text-gray-600">Enter your name to save scores:</p>
+          <div className="flex items-center gap-2 justify-center">
+            <Input value={nameInput} onChange={(e) => setNameInput(e.target.value)} className="w-40" />
+            <Button size="sm" onClick={() => setPlayerName(nameInput)}>
+              Save
+            </Button>
+          </div>
+        </div>
       )}
       <Button 
         onClick={onPlayAgain}

--- a/src/components/GameModeSelector.tsx
+++ b/src/components/GameModeSelector.tsx
@@ -105,9 +105,9 @@ const GameModeSelector: React.FC<GameModeSelectorProps> = ({
 
           <Card className="p-4 bg-white/90 backdrop-blur-sm shadow-xl">
             <h4 className="font-semibold text-gray-800 mb-3 text-center">👤 Your Best Times</h4>
-            {!user ? (
+            {!user && personalScores.length === 0 ? (
               <div className="text-sm text-gray-500 italic text-center">
-                Sign in with Google to track your scores!
+                Play a game to see your scores!
               </div>
             ) : loading ? (
               <div className="text-center text-sm text-gray-500">Loading...</div>
@@ -115,7 +115,7 @@ const GameModeSelector: React.FC<GameModeSelectorProps> = ({
               <div className="space-y-1 text-sm">
                 {personalScores.slice(0, 5).map((score, index) => (
                   <div key={score.id} className="flex justify-between">
-                    <span>{index + 1}. Your best</span>
+                    <span>{index + 1}. {user ? 'Your best' : 'Best time'}</span>
                     <span className="font-mono">{formatTime(score.time_elapsed)}</span>
                   </div>
                 ))}

--- a/src/components/PlayerName.tsx
+++ b/src/components/PlayerName.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { usePlayerName } from '@/hooks/usePlayerName';
+
+const PlayerName: React.FC = () => {
+  const { playerName, setPlayerName } = usePlayerName();
+  const [editing, setEditing] = useState(false);
+  const [tempName, setTempName] = useState(playerName);
+
+  const handleSave = () => {
+    setPlayerName(tempName.trim());
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-2">
+        <input
+          className="px-2 py-1 rounded text-black"
+          value={tempName}
+          onChange={(e) => setTempName(e.target.value)}
+          autoFocus
+        />
+        <button onClick={handleSave} className="text-sm underline text-white">
+          Save
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={() => setEditing(true)}
+      className="text-white hover:text-blue-200"
+    >
+      {playerName || 'Set Name'}
+    </button>
+  );
+};
+
+export default PlayerName;

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/hooks/usePlayerName.ts
+++ b/src/hooks/usePlayerName.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+const PLAYER_NAME_KEY = 'player_name';
+
+export const usePlayerName = () => {
+  const [playerName, setPlayerNameState] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem(PLAYER_NAME_KEY);
+    if (stored) {
+      setPlayerNameState(stored);
+    }
+  }, []);
+
+  const setPlayerName = (name: string) => {
+    setPlayerNameState(name);
+    localStorage.setItem(PLAYER_NAME_KEY, name);
+  };
+
+  return { playerName, setPlayerName };
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import FlagGame from '@/components/FlagGame';
 import AuthButton from '@/components/AuthButton';
 import ProfileSettings from '@/components/ProfileSettings';
+import PlayerName from '@/components/PlayerName';
 import { useAuth } from '@/contexts/AuthContext';
 
 const Index = () => {
@@ -23,7 +24,7 @@ const Index = () => {
       
       <div className="relative z-10 max-w-5xl mx-auto">
         <div className="flex justify-between items-center mb-6">
-          <div></div>
+          <PlayerName />
           <div className="flex items-center gap-4">
             {user && (
               <button

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -92,5 +93,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+       plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- store and edit player name locally
- keep local high scores for guests
- prompt for a name on game completion when not logged in
- show name at the top left of the page
- document the new feature

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c8c11ba7c833388b1e5e070405747